### PR TITLE
Add option to send both event types to GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Unreleased
 
-* Push ecommerce event to Google Analytics
+* Fixed typo in variable name
+* New option to send ecommerce transaction _and_ event, alongside one or the other
+* Simpler language for settings page field labels
 
 ## 0.1.0 - 2018-11-06
 
 ### Added
 
 * CHANGELOG.md
+* Push ecommerce event or standard event to Google Analytics
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 * Fixed typo in variable name
 * New option to send ecommerce transaction _and_ event, alongside one or the other
 * Simpler language for settings page field labels
+* Changed standard event label and value to use Civi form ID and PayPal trxn ID respectively
 
 ## 0.1.0 - 2018-11-06
 

--- a/CRM/Trackpaypal/Form/Settings.php
+++ b/CRM/Trackpaypal/Form/Settings.php
@@ -13,6 +13,7 @@ class CRM_Trackpaypal_Form_Settings extends CRM_Core_Form {
     return array(
       'standard' => 'standard',
       'ecommerce' => 'ecommerce',
+      'both' => 'both',
     );
   }
 

--- a/CRM/Trackpaypal/Form/Settings.php
+++ b/CRM/Trackpaypal/Form/Settings.php
@@ -17,6 +17,13 @@ class CRM_Trackpaypal_Form_Settings extends CRM_Core_Form {
     );
   }
 
+  public static function debugMode() {
+    return array(
+      'on' => 'on',
+      'off' => 'off',
+    );
+  }
+
   private $_settingFilter = array('group' => 'trackpaypal');
   private $_submittedValues = array();
   private $_settings = array();

--- a/settings/Trackpaypal.setting.php
+++ b/settings/Trackpaypal.setting.php
@@ -44,8 +44,8 @@ return array(
     'add' => '4.7',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'Google Analytics event type sent when PayPal IPN received',
-    'title' => 'Google Analytics event type',
+    'description' => 'Send eCommerce Transaction, standard Event or both to Google Analytics?',
+    'title' => 'Data to send to GA',
     'default' => array('ecommerce'),
     'html_type' => 'Select',
     'pseudoconstant' => array(
@@ -63,7 +63,7 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'Google Analytics tracking code (UA-XXXXXX-X)',
-    'title' => 'Google Analytics Tracking Code',
+    'title' => 'Tracking Code',
     'html_type' => 'Text',
     'html_attributes' => array(
       'size' => 18,
@@ -71,4 +71,23 @@ return array(
     ),
     'quick_form_type' => 'Element',
   ),
+  'trackpaypal_event_category' => array(
+    'group_name' => 'trackpaypal',
+    'group' => 'trackpaypal',
+    'name' => 'trackpaypal_event_category',
+    'filter' => 'trackpaypal',
+    'type' => 'String',
+    'add' => '4.7',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Google Analytics Event Category term. Defaults to "Transaction" if blank.',
+    'title' => 'Event Category',
+    'html_type' => 'Text',
+    'html_attributes' => array(
+      'size' => 18,
+      'maxlength' => 16,
+    ),
+    'quick_form_type' => 'Element',
+  ),
+
 );

--- a/settings/Trackpaypal.setting.php
+++ b/settings/Trackpaypal.setting.php
@@ -89,5 +89,23 @@ return array(
     ),
     'quick_form_type' => 'Element',
   ),
+  'trackpaypal_debug_mode' => array(
+    'group_name' => 'trackpaypal',
+    'group' => 'trackpaypal',
+    'name' => 'trackpaypal_debug_mode',
+    'filter' => 'trackpaypal',
+    'type' => 'String',
+    'add' => '4.7',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Enable debug mode? Logs GA validation data to ConfigAndLog',
+    'title' => 'Debug mode',
+    'default' => array('off'),
+    'html_type' => 'Select',
+    'pseudoconstant' => array(
+      'callback' => 'CRM_Trackpaypal_Form_Settings::debugMode',
+    ),
+    'quick_form_type' => 'Element',
+  ),
 
 );

--- a/templates/CRM/Trackpaypal/Form/Settings.tpl
+++ b/templates/CRM/Trackpaypal/Form/Settings.tpl
@@ -12,8 +12,10 @@
     <div class="content">{$form.$elementName.html}<br>
       {if $elementName eq "trackpaypal_event_type"}
         {$trackpaypal_event_type_description}
-      {else}
+      {elseif $elementName eq "trackpaypal_tracking_code"}
         {$trackpaypal_tracking_code_description}
+      {else}
+        {$trackpaypal_event_category_description}
       {/if}
     </div>
     <div class="clear"></div>

--- a/templates/CRM/Trackpaypal/Form/Settings.tpl
+++ b/templates/CRM/Trackpaypal/Form/Settings.tpl
@@ -14,8 +14,10 @@
         {$trackpaypal_event_type_description}
       {elseif $elementName eq "trackpaypal_tracking_code"}
         {$trackpaypal_tracking_code_description}
-      {else}
+      {elseif $elementName eq "trackpaypal_event_category"}
         {$trackpaypal_event_category_description}
+      {else}
+        {$trackpaypal_debug_mode_description}
       {/if}
     </div>
     <div class="clear"></div>

--- a/trackpaypal.php
+++ b/trackpaypal.php
@@ -215,6 +215,8 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
   // Retrieve extension settings
     $event_type = Civi::settings()->get('trackpaypal_event_type');
     $tracking_code = Civi::settings()->get('trackpaypal_tracking_code');
+    $event_category = Civi::settings()->get('trackpaypal_event_category');
+    if ($event_category = "") { $event_category = 'Transaction' };
 
   // Check the GA Code is of valid syntax
   // If not we do nothing
@@ -226,6 +228,7 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
   // Retrieve IPN packet data
   $customPayload = json_decode($IPNData['custom'], TRUE);
   $gcid = $customPayload['gcid'];
+  $form_id = $customPayload['contributionPageID'];
   $trxn_id = $IPNData['txn_id'];
   $revenue = $IPNData['mc_gross'];
   $currency = $IPNData['mc_currency'];
@@ -253,10 +256,10 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
         'tid' => $tracking_code,
         'cid' => $gcid,
         't' => 'event',
-        'ec' => 'transaction',
+        'ec' => $event_category,
         'ea' => 'purchase',
-        'el' => $trxn_id,
-        'ev' => $revenue,
+        'el' => $form_id,
+        'ev' => $trxn_id,
       ]
     ]);
   }
@@ -278,10 +281,10 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
         'tid' => $tracking_code,
         'cid' => $gcid,
         't' => 'event',
-        'ec' => 'transaction',
+        'ec' => $event_category,
         'ea' => 'purchase',
-        'el' => $trxn_id,
-        'ev' => $revenue,
+        'el' => $form_id,
+        'ev' => $trxn_id,
       ]
     ]);
   }

--- a/trackpaypal.php
+++ b/trackpaypal.php
@@ -195,7 +195,6 @@ function trackpaypal_civicrm_alterPaymentProcessorParams($paymentObj,&$rawParams
     return;
   }
   else {
-    $cookedParams['notify_url'] = 'http://mrlavalava.hopto.org:5555/civicrm/payment/ipn/3?';
     if (isset($cookedParams['custom'])) {
       // Add the Google Analytics client ID value
       // to the JSON encoded 'custom' attribute

--- a/trackpaypal.php
+++ b/trackpaypal.php
@@ -250,7 +250,7 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
     $result = $client->request('POST', '/collect', [
       'form_params' => [
         'v' => '1',
-        'tid' => $tracking_cide,
+        'tid' => $tracking_code,
         'cid' => $gcid,
         't' => 'event',
         'ec' => 'transaction',
@@ -260,7 +260,31 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
       ]
     ]);
   }
-
+  else if ($event_type == 'both') {
+    $result = $client->request('POST', '/collect', [
+      'form_params' => [
+        'v' => '1',
+        'tid' => $tracking_code,
+        'cid' => $gcid,
+        't' => 'transaction',
+        'ti' => $trxn_id,
+        'tr' => $revenue,
+        'cu' => $currency,
+      ]
+    ]);
+    $result = $client->request('POST', '/collect', [
+      'form_params' => [
+        'v' => '1',
+        'tid' => $tracking_code,
+        'cid' => $gcid,
+        't' => 'event',
+        'ec' => 'transaction',
+        'ea' => 'purchase',
+        'el' => $trxn_id,
+        'ev' => $revenue,
+      ]
+    ]);
+  }
 }
 
 function trackpaypal_isGACode($str) {

--- a/trackpaypal.php
+++ b/trackpaypal.php
@@ -216,7 +216,7 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
     $event_type = Civi::settings()->get('trackpaypal_event_type');
     $tracking_code = Civi::settings()->get('trackpaypal_tracking_code');
     $event_category = Civi::settings()->get('trackpaypal_event_category');
-    if ($event_category = "") { $event_category = 'Transaction' };
+    if ($event_category = "") { $event_category = 'Transaction'; }
 
   // Check the GA Code is of valid syntax
   // If not we do nothing

--- a/trackpaypal.php
+++ b/trackpaypal.php
@@ -195,6 +195,7 @@ function trackpaypal_civicrm_alterPaymentProcessorParams($paymentObj,&$rawParams
     return;
   }
   else {
+    $cookedParams['notify_url'] = 'http://mrlavalava.hopto.org:5555/civicrm/payment/ipn/3?';
     if (isset($cookedParams['custom'])) {
       // Add the Google Analytics client ID value
       // to the JSON encoded 'custom' attribute
@@ -269,17 +270,25 @@ function trackpaypal_civicrm_postIPNProcess(&$IPNData) {
 
   if ($event_type == 'ecommerce') {
     $result = $client->request('POST', $endpoint, $packet_ecommerce);
-    if ($debug_mode == 'on') { trackpaypal_logValidation($result); }
+    if ($debug_mode == 'on') {
+      trackpaypal_logValidation($result);
+    }
   }
   else if ($event_type == 'standard') {
     $result = $client->request('POST', $endpoint, $packet_event);
-    if ($debug_mode == 'on') { trackpaypal_logValidation($result); }
+    if ($debug_mode == 'on') {
+      trackpaypal_logValidation($result);
+    }
   }
   else if ($event_type == 'both') {
     $result = $client->request('POST', $endpoint, $packet_ecommerce);
-    if ($debug_mode == 'on') { trackpaypal_logValidation($result); }
+    if ($debug_mode == 'on') {
+      trackpaypal_logValidation($result);
+    }
     $result = $client->request('POST', $endpoint, $packet_event);
-    if ($debug_mode == 'on') { trackpaypal_logValidation($result); }
+    if ($debug_mode == 'on') {
+      trackpaypal_logValidation($result);
+    }
   }
 }
 


### PR DESCRIPTION
Adds a new option to send both an eCommerce Transaction event _and_ a standard Event to Google Analytics.

Fixes a minor typo in a variable name.

Cleans up language of settings page field labels.